### PR TITLE
Feat/pull from vault setup

### DIFF
--- a/script/ArchitectureDeployments/DeployArcticArchitecture.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitecture.sol
@@ -34,6 +34,7 @@ contract DeployArcticArchitecture is Script, ContractNames {
         bool finishSetup;
         bool setupTestUser;
         bool saveDeploymentDetails;
+        bool initiatePullFundsFromVault;
         address deployerAddress;
         address balancerVault;
         address WETH;
@@ -634,6 +635,16 @@ contract DeployArcticArchitecture is Script, ContractNames {
                 );
             }
 
+            if (
+                !rolesAuthority.doesRoleHaveCapability(
+                    MULTISIG_ROLE, address(delayedWithdrawer), DelayedWithdraw.setPullFundsFromVault.selector
+                )
+            ) {
+                rolesAuthority.setRoleCapability(
+                    MULTISIG_ROLE, address(delayedWithdrawer), DelayedWithdraw.setPullFundsFromVault.selector, true
+                );
+            }
+
             // STRATEGIST_MULTISIG_ROLE
             if (
                 !rolesAuthority.doesRoleHaveCapability(
@@ -675,6 +686,15 @@ contract DeployArcticArchitecture is Script, ContractNames {
             ) {
                 rolesAuthority.setRoleCapability(
                     STRATEGIST_MULTISIG_ROLE, address(delayedWithdrawer), DelayedWithdraw.setFeeAddress.selector, true
+                );
+            }
+            if (
+                !rolesAuthority.doesRoleHaveCapability(
+                    STRATEGIST_MULTISIG_ROLE, address(delayedWithdrawer), DelayedWithdraw.setPullFundsFromVault.selector
+                )
+            ) {
+                rolesAuthority.setRoleCapability(
+                    STRATEGIST_MULTISIG_ROLE, address(delayedWithdrawer), DelayedWithdraw.setPullFundsFromVault.selector, true
                 );
             }
             // STRATEGIST_ROLE
@@ -818,6 +838,11 @@ contract DeployArcticArchitecture is Script, ContractNames {
                     withdrawAsset.maxLoss
                 );
             }
+        }
+
+        if (configureDeployment.initiatePullFundsFromVault) {
+            // Setup pull funds from vault.
+            delayedWithdrawer.setPullFundsFromVault(configureDeployment.initiatePullFundsFromVault);
         }
 
         if (configureDeployment.finishSetup) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes

Fixes #81

#### Additional comments
   
- Introduces the `initiatePullFundsFromVault` variable to potentially set `pullFundsFromVault` to `true` during deployment as needed.
- Establishes role capability to alter `pullFundsFromVault` via the `setPullFundsFromVault` function for the roles `MULTISIG_ROLE` and `STRATEGIST_MULTISIG_ROLE`

edit: i guess this won't work in previous deployments, as establishing capabilities will fail for those deployments that don't have the setPullFundsFromVault function.
