### PR TITLE
Dev/september 2024

### DIFF
--- a/src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol
+++ b/src/base/DecodersAndSanitizers/Protocols/UniswapV3DecoderAndSanitizer.sol
@@ -61,14 +61,11 @@ abstract contract UniswapV3DecoderAndSanitizer is BaseDecoderAndSanitizer {
         virtual
         returns (bytes memory addressesFound)
     {
-        // Sanitize raw data
-        if (uniswapV3NonFungiblePositionManager.ownerOf(params.tokenId) != boringVault) {
-            revert UniswapV3DecoderAndSanitizer__BadTokenId();
-        }
         // Extract addresses from uniswapV3NonFungiblePositionManager.positions(params.tokenId).
+        address ownerOfTokenId = uniswapV3NonFungiblePositionManager.ownerOf(params.tokenId); 
         (, address operator, address token0, address token1,,,,,,,,) =
             uniswapV3NonFungiblePositionManager.positions(params.tokenId);
-        addressesFound = abi.encodePacked(operator, token0, token1);
+        addressesFound = abi.encodePacked(operator, token0, token1, ownerOfTokenId);
     }
 
     function decreaseLiquidity(DecoderCustomTypes.DecreaseLiquidityParams calldata params)
@@ -80,12 +77,9 @@ abstract contract UniswapV3DecoderAndSanitizer is BaseDecoderAndSanitizer {
         // Sanitize raw data
         // NOTE ownerOf check is done in PositionManager contract as well, but it is added here
         // just for completeness.
-        if (uniswapV3NonFungiblePositionManager.ownerOf(params.tokenId) != boringVault) {
-            revert UniswapV3DecoderAndSanitizer__BadTokenId();
-        }
-
+        address ownerOfTokenId = uniswapV3NonFungiblePositionManager.ownerOf(params.tokenId); 
         // No addresses in data
-        return addressesFound;
+        addressesFound = abi.encodePacked(ownerOfTokenId); 
     }
 
     function collect(DecoderCustomTypes.CollectParams calldata params)
@@ -97,12 +91,9 @@ abstract contract UniswapV3DecoderAndSanitizer is BaseDecoderAndSanitizer {
         // Sanitize raw data
         // NOTE ownerOf check is done in PositionManager contract as well, but it is added here
         // just for completeness.
-        if (uniswapV3NonFungiblePositionManager.ownerOf(params.tokenId) != boringVault) {
-            revert UniswapV3DecoderAndSanitizer__BadTokenId();
-        }
-
+        address ownerOfTokenId = uniswapV3NonFungiblePositionManager.ownerOf(params.tokenId); 
         // Return addresses found
-        addressesFound = abi.encodePacked(params.recipient);
+        addressesFound = abi.encodePacked(params.recipient, ownerOfTokenId);
     }
 
     function burn(uint256 /*tokenId*/ ) external pure virtual returns (bytes memory addressesFound) {

--- a/test/integrations/UniswapV3Integration.t.sol
+++ b/test/integrations/UniswapV3Integration.t.sol
@@ -360,8 +360,13 @@ contract UniswapV3IntegrationTest is Test, MerkleTreeHelper {
         );
 
         vm.expectRevert(
-            abi.encodeWithSelector(UniswapV3DecoderAndSanitizer.UniswapV3DecoderAndSanitizer__BadTokenId.selector)
-        );
+            abi.encodeWithSelector(
+                ManagerWithMerkleVerification.ManagerWithMerkleVerification__FailedToVerifyManageProof.selector, 
+                getAddress(sourceChain, "uniswapV3NonFungiblePositionManager"), //address target
+                targetData[5], //bytes32 targetData
+                0 //uint256 value
+            )
+        ); 
         manager.manageVaultWithMerkleVerification(
             manageProofs, decodersAndSanitizers, targets, targetData, new uint256[](8)
         );
@@ -378,10 +383,15 @@ contract UniswapV3IntegrationTest is Test, MerkleTreeHelper {
         targetData[6] = abi.encodeWithSignature(
             "decreaseLiquidity((uint256,uint128,uint256,uint256,uint256))", decreaseLiquidityParams
         );
-
+        
         vm.expectRevert(
-            abi.encodeWithSelector(UniswapV3DecoderAndSanitizer.UniswapV3DecoderAndSanitizer__BadTokenId.selector)
-        );
+            abi.encodeWithSelector(
+                ManagerWithMerkleVerification.ManagerWithMerkleVerification__FailedToVerifyManageProof.selector, 
+                getAddress(sourceChain, "uniswapV3NonFungiblePositionManager"),
+                targetData[6],
+                0
+            )
+        ); 
         manager.manageVaultWithMerkleVerification(
             manageProofs, decodersAndSanitizers, targets, targetData, new uint256[](8)
         );
@@ -398,9 +408,7 @@ contract UniswapV3IntegrationTest is Test, MerkleTreeHelper {
         );
         targetData[7] = abi.encodeWithSignature("collect((uint256,address,uint128,uint128))", collectParams);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(UniswapV3DecoderAndSanitizer.UniswapV3DecoderAndSanitizer__BadTokenId.selector)
-        );
+        vm.expectRevert();
         manager.manageVaultWithMerkleVerification(
             manageProofs, decodersAndSanitizers, targets, targetData, new uint256[](8)
         );

--- a/test/integrations/UniswapV3Integration.t.sol
+++ b/test/integrations/UniswapV3Integration.t.sol
@@ -408,7 +408,14 @@ contract UniswapV3IntegrationTest is Test, MerkleTreeHelper {
         );
         targetData[7] = abi.encodeWithSignature("collect((uint256,address,uint128,uint128))", collectParams);
 
-        vm.expectRevert();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ManagerWithMerkleVerification.ManagerWithMerkleVerification__FailedToVerifyManageProof.selector, 
+                getAddress(sourceChain, "uniswapV3NonFungiblePositionManager"),
+                targetData[7],
+                0
+            )
+        );
         manager.manageVaultWithMerkleVerification(
             manageProofs, decodersAndSanitizers, targets, targetData, new uint256[](8)
         );

--- a/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
+++ b/test/resources/MerkleTreeHelper/MerkleTreeHelper.sol
@@ -2349,7 +2349,7 @@ contract MerkleTreeHelper is CommonBase, ChainValues {
                 getAddress(sourceChain, "uniswapV3NonFungiblePositionManager"),
                 false,
                 "increaseLiquidity((uint256,uint256,uint256,uint256,uint256,uint256))",
-                new address[](3),
+                new address[](4),
                 string.concat(
                     "Add liquidity to UniswapV3 ",
                     ERC20(token0[i]).symbol(),
@@ -2362,6 +2362,7 @@ contract MerkleTreeHelper is CommonBase, ChainValues {
             leafs[leafIndex].argumentAddresses[0] = address(0);
             leafs[leafIndex].argumentAddresses[1] = token0[i];
             leafs[leafIndex].argumentAddresses[2] = token1[i];
+            leafs[leafIndex].argumentAddresses[3] = getAddress(sourceChain, "boringVault"); 
 
             // Swapping to move tick in pool.
             unchecked {
@@ -2405,10 +2406,12 @@ contract MerkleTreeHelper is CommonBase, ChainValues {
             getAddress(sourceChain, "uniswapV3NonFungiblePositionManager"),
             false,
             "decreaseLiquidity((uint256,uint128,uint256,uint256,uint256))",
-            new address[](0),
+            new address[](1),
             "Remove liquidity from UniswapV3 position",
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
+        leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault"); 
+
         unchecked {
             leafIndex++;
         }
@@ -2416,11 +2419,12 @@ contract MerkleTreeHelper is CommonBase, ChainValues {
             getAddress(sourceChain, "uniswapV3NonFungiblePositionManager"),
             false,
             "collect((uint256,address,uint128,uint128))",
-            new address[](1),
+            new address[](2),
             "Collect fees from UniswapV3 position",
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
         leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault");
+        leafs[leafIndex].argumentAddresses[1] = getAddress(sourceChain, "boringVault"); //two params returns, so two of these?
 
         // burn
         unchecked {
@@ -2606,6 +2610,7 @@ contract MerkleTreeHelper is CommonBase, ChainValues {
             getAddress(sourceChain, "rawDataDecoderAndSanitizer")
         );
         leafs[leafIndex].argumentAddresses[0] = getAddress(sourceChain, "boringVault");
+        leafs[leafIndex].argumentAddresses[1] = getAddress(sourceChain, "boringVault");  //do we need this twice if two params?  
 
         // burn
         unchecked {


### PR DESCRIPTION
- Remove UniswapV3 Sanitizer/Decoder checks for TokenID 
- Add leaves in `MerkleTreeHelper` to return owner address 
- change revert statements to ensure new errors are being checked instead of `BadTokenID`